### PR TITLE
orientation video player dimensions

### DIFF
--- a/ReactNativeDemo2/App.tsx
+++ b/ReactNativeDemo2/App.tsx
@@ -55,6 +55,10 @@ function App(): JSX.Element {
       setVideoHeight(newOrientation === ORIENTATION_PORTRAIT ? VIDEO_PORTRAIT_HEIGHT : height);
     };
     Dimensions.addEventListener('change', handleOrientationChange);
+
+    return () => {
+      Dimensions.removeEventListener('change', handleOrientationChange);
+    };
   }, []);
   
   return (


### PR DESCRIPTION
## Description
This PR is to 
- update the video player dimensions when the device orientation changes 
- the player will have full width and height when the device orientation is a landscape and will have a small height when the orientation is a portrait 
<img width="554" alt="landscape" src="https://github.com/buffup/SportbuffReactNativeDemo/assets/10253129/85318843-c35b-459e-8a1c-8de223dfd26e">
<img width="293" alt="portrait" src="https://github.com/buffup/SportbuffReactNativeDemo/assets/10253129/996e14e9-cca7-4878-9cef-58a3a7848dac">


## Type of change
- [x]  New Feature